### PR TITLE
Fix log filling when locale not English

### DIFF
--- a/everrest-websockets/src/main/java/org/everrest/websockets/client/WSClient.java
+++ b/everrest-websockets/src/main/java/org/everrest/websockets/client/WSClient.java
@@ -491,7 +491,7 @@ public class WSClient {
     private void validateResponseHeaders() throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(in));
         String line = br.readLine();
-        if (!"HTTP/1.1 101 Switching Protocols".equals(line)) {
+        if (line != null && !line.startsWith("HTTP/1.1 101")) {
             throw new IOException("Invalid server response. Expected status is 101 'Switching Protocols'. ");
         }
 


### PR DESCRIPTION
When locale is not English, logs are filled with those messages:
“Invalid server response. Expected status is 101 'Switching Protocols'.”.
Comparison should only be done on the first part of the String.
