### PR TITLE
Fixed defaults components reset

### DIFF
--- a/everrest-assured/src/main/java/org/everrest/assured/JettyHttpServer.java
+++ b/everrest-assured/src/main/java/org/everrest/assured/JettyHttpServer.java
@@ -30,7 +30,6 @@ import org.everrest.core.ResourceBinder;
 import org.everrest.core.impl.ApplicationProviderBinder;
 import org.everrest.core.impl.ApplicationProviderBinderHelper;
 import org.everrest.core.impl.ApplicationPublisher;
-import org.everrest.core.impl.ProviderBinder;
 import org.everrest.core.impl.ResourceBinderImpl;
 import org.everrest.core.servlet.EverrestInitializedListener;
 import org.everrest.core.servlet.EverrestServlet;
@@ -211,8 +210,6 @@ public class JettyHttpServer {
                 (ApplicationProviderBinder)context.getServletContext().getAttribute(ApplicationProviderBinder.class.getName());
 
         ApplicationProviderBinderHelper.resetApplicationProviderBinder(providerBinder);
-        ProviderBinder.setInstance(null);
-
     }
 
 

--- a/everrest-assured/src/main/java/org/everrest/core/impl/ApplicationProviderBinderHelper.java
+++ b/everrest-assured/src/main/java/org/everrest/core/impl/ApplicationProviderBinderHelper.java
@@ -15,14 +15,6 @@ public class ApplicationProviderBinderHelper {
         binder.readProviders.clear();
         binder.responseFilters.clear();
         binder.invokerFilters.clear();
-        ProviderBinder defaults = ProviderBinder.getInstance();
-        binder.writeProviders.putAll(defaults.writeProviders);
-        binder.readProviders.putAll(defaults.readProviders);
-        binder.exceptionMappers.putAll(defaults.exceptionMappers);
-        binder.contextResolvers.putAll(defaults.contextResolvers);
-        binder.readProviders.putAll(defaults.readProviders);
-        binder.responseFilters.putAll(defaults.responseFilters);
-        binder.invokerFilters.putAll(defaults.invokerFilters);
         binder.addMethodInvokerFilter(new SecurityConstraint());
     }
 }

--- a/everrest-assured/src/test/java/org/everrest/assured/ProviderTest.java
+++ b/everrest-assured/src/test/java/org/everrest/assured/ProviderTest.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2016 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package org.everrest.assured;
+
+import com.jayway.restassured.response.Response;
+
+import org.everrest.sample.book.Book;
+import org.everrest.sample.book.BookService;
+import org.everrest.sample.book.BookStorage;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+/** Test of exception mapper testing. */
+@Listeners(value = {EverrestJetty.class, MockitoTestNGListener.class})
+public class ProviderTest {
+    @Mock
+    private BookStorage bookStorage;
+
+    private BookJsonProvider bookJsonProvider;
+
+    @InjectMocks
+    private BookService bookService;
+
+    @Test
+    public void shoudlThrow404IfBookIsNotFound() throws Exception {
+        when(bookStorage.getBook(eq("123-1235-555"))).thenReturn(new Book());
+
+        //unsecure call to rest service
+        final Response response = given().pathParam("id", "123-1235-555")
+                                         .expect()
+                                         .statusCode(200)
+                                         .when()
+                                         .get("/books/{id}");
+        assertEquals(response.getBody().print(), "ping");
+    }
+
+
+    @Provider
+    @Produces(MediaType.APPLICATION_JSON)
+    public static class BookJsonProvider implements MessageBodyReader<Book>, MessageBodyWriter<Book> {
+        @Override
+        public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return type.isAssignableFrom(Book.class);
+        }
+
+        @Override
+        public Book readFrom(Class<Book> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                             MultivaluedMap<String, String> httpHeaders, InputStream entityStream)
+                throws IOException, WebApplicationException {
+            return null;
+        }
+
+        @Override
+        public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return type.isAssignableFrom(Book.class);
+        }
+
+        @Override
+        public long getSize(Book book, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+            return -1;
+        }
+
+        @Override
+        public void writeTo(Book book, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                            MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream)
+                throws IOException, WebApplicationException {
+            entityStream.write("ping".getBytes());
+        }
+    }
+}


### PR DESCRIPTION
Correctly reset internal state of Everrest components.
No need to set defaults in ApplicationProviderBinder. They be provided internaly by ApplicationProviderBinder