### PR TITLE
Fix request dispatching

### DIFF
--- a/everrest-core/src/main/java/org/everrest/core/impl/RequestDispatcher.java
+++ b/everrest-core/src/main/java/org/everrest/core/impl/RequestDispatcher.java
@@ -544,7 +544,9 @@ public class RequestDispatcher {
                 String lastCapturedValue = Iterables.getLast(capturedValues);
                 if (lastCapturedValue == null || "/".equals(lastCapturedValue)) {
                     resourceMethods = entry.getValue();
-                    break;
+                    if (resourceMethods.containsKey(request.getMethod())) {
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix dispatching when two subresources have different paths and requested path matches to more than one but only one subresource has requested http method.

In other words it fixes request dispatching for services like following one:
```
@Path("/test")
public class TestService {
  @GET
  @Path("/{key:.*}")
  public void get(@PathParam("key") String key) {
  }
  
  @DELETE
  @Path("/{id}")
  public void delete(@PathParam("id") String id) {
  }

  @PUT
  @Path("/put")
  public void put() {
  }
}
```