### PR TITLE
Update commons-fileupload library

### DIFF
--- a/everrest-core/src/main/java/org/everrest/core/impl/provider/ext/InMemoryFileItem.java
+++ b/everrest-core/src/main/java/org/everrest/core/impl/provider/ext/InMemoryFileItem.java
@@ -11,6 +11,7 @@
 package org.everrest.core.impl.provider.ext;
 
 import org.apache.commons.fileupload.FileItem;
+import org.apache.commons.fileupload.FileItemHeaders;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
@@ -44,6 +45,7 @@ class InMemoryFileItem implements FileItem {
     private String                contentType;
     private String                fieldName;
     private boolean               isFormField;
+    private FileItemHeaders       headers;
 
     InMemoryFileItem(String contentType, String fieldName, boolean isFormField, String fileName, int maxSize) {
         this.contentType = contentType;
@@ -159,5 +161,15 @@ class InMemoryFileItem implements FileItem {
     @Override
     public void write(File file) throws Exception {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public FileItemHeaders getHeaders() {
+        return headers;
+    }
+
+    @Override
+    public void setHeaders(FileItemHeaders headers) {
+        this.headers = headers;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <com.google.code.guice.version>4.1.0</com.google.code.guice.version>
         <com.google.guava.version>18.0</com.google.guava.version>
         <com.tngtech.java>1.9.3</com.tngtech.java>
-        <commons-fileupload.version>1.2.1</commons-fileupload.version>
+        <commons-fileupload.version>1.3.3</commons-fileupload.version>
         <commons-io.version>2.4</commons-io.version>
         <currentYear>2016</currentYear>
         <gpg.useagent>true</gpg.useagent>


### PR DESCRIPTION
Update commons-fileupload library
Needed fix for security vulnerability in Apache FileUpload:
https://nvd.nist.gov/vuln/detail/CVE-2014-0050
https://www.exploit-db.com/exploits/31615/